### PR TITLE
Added installation instruction on Apahce httpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,27 @@ PASS:  crypto-test 2: password checktext generation/validation
   - apriconv
   - apr
   - expat
+
+## Install On Apahce httpd
+
+1. copy *mod_dav_svn.so*, *mod_authz_svn.so*, **and all *.dll* files under */deps*** to Apache httpd *modules/* folder
+2. load the modules by adding following lines in apache config
+
+    ```
+    LoadModule dav_svn_module modules/mod_dav_svn.so
+    LoadModule authz_svn_module modules/mod_authz_svn.so
+    ```
+3.  add svn directives to  apache config. If using [mod_authn_ntlm](https://github.com/TQsoft-GmbH/mod_authn_ntlm) for authentication, the directives will look like
+
+    ```
+    <Location /svn>
+        NTLMAuth on
+        NTLMUsernameCase  lower
+        NTLMOfferBasic On
+        DAV svn
+        SVNPath "c:\svn_repo"
+        SVNReposName "My Subversion Repository"
+        AuthzSVNAccessFile "c:\svn_repo\conf\authz"
+        Require valid-user
+    </Location>
+    ```

--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ PASS:  crypto-test 2: password checktext generation/validation
 
 ## Install On Apahce httpd
 
-1. copy *mod_dav_svn.so*, *mod_authz_svn.so*, **and all *.dll* files under */deps*** to Apache httpd *modules/* folder
-2. load the modules by adding following lines in apache config
+1. add win-svn/vc15/(x64|x86) to *PATH* environment variable
+2. copy *mod_dav_svn.so*, *mod_authz_svn.so*, **and all *.dll* files under */deps*** to Apache httpd *modules/* folder
+3. load the modules by adding following lines in apache config
 
     ```
     LoadModule dav_svn_module modules/mod_dav_svn.so
     LoadModule authz_svn_module modules/mod_authz_svn.so
     ```
-3.  add svn directives to  apache config. If using [mod_authn_ntlm](https://github.com/TQsoft-GmbH/mod_authn_ntlm) for authentication, the directives will look like
+4.  add svn directives to  apache config. If using [mod_authn_ntlm](https://github.com/TQsoft-GmbH/mod_authn_ntlm) for authentication, the directives will look like
 
     ```
     <Location /svn>


### PR DESCRIPTION
Hi, 
Thanks for maintaining this repo. With it, I successfully ported svn server from apache 2.2 to 2.4 x64 . Initially it didn't work. I got error
```
Cannot load modules/mod_dav_svn.so into server: The specified module could not be found.
```
After some troubleshooting, I figured out I have to copy all deps dll to *modules* folder as well. The old svn binary distros combine all deps into the .so files so they don't have this caveat. I created this pr intended to clarify.